### PR TITLE
onValueChange is not a default prop

### DIFF
--- a/src/Select.js
+++ b/src/Select.js
@@ -86,7 +86,7 @@ class Select extends Component {
       showSelector: false,
       value: newValue
     }, () => {
-      this.props.onValueChange && this.props.onValueChange(newValue)
+      this.props.onValueChange(newValue)
     })
   }
 
@@ -146,6 +146,7 @@ Select.PropTypes = {
 }
 
 Select.defaultProps = {
+  onValueChange: () => {},
   placeholder: '',
   labelKey: 'label',
   valueKey: 'value',

--- a/src/Select.js
+++ b/src/Select.js
@@ -86,7 +86,7 @@ class Select extends Component {
       showSelector: false,
       value: newValue
     }, () => {
-      this.props.onValueChange(newValue)
+      this.props.onValueChange && this.props.onValueChange(newValue)
     })
   }
 


### PR DESCRIPTION
throws error that function props.onValueChange does not exist. I changed to make it ignore the function call if it doesn't exists.