### PR TITLE
Fix errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 example/
 .idea
 .babelrc
+node_modules/

--- a/src/redux-form/index.js
+++ b/src/redux-form/index.js
@@ -2,8 +2,14 @@ import createInputs from './createInputs'
 import createInputCreator from './createInputCreator'
 import { Field } from 'redux-form'
 
+const {
+  Input,
+  Select,
+  Switch
+} = createInputs(createInputCreator(Field))
+
 export {
   Input,
   Select,
   Switch
-} from createInputs(createInputCreator(Field))
+}


### PR DESCRIPTION
React Native tries to bundle up the node_modules and breaks.

Exporting components straight from a function doesn't seem to be supported.