### PR TITLE
Fix the dependencies to react-native and vector-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-clean-form",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "An example of creating mobile forms with React Native, styled-components and redux-form",
   "main": "index.js",
   "directories": {
@@ -24,16 +24,19 @@
     "url": "https://github.com/esbenp/react-native-clean-form/issues"
   },
   "homepage": "https://github.com/esbenp/react-native-clean-form#readme",
-  "dependencies": {
-    "react-native": "^0.40.0",
-    "react-native-vector-icons": "^3.0.0",
-    "styled-components": "^1.2.1"
-  },
-  "devDependencies": {
-  },
   "files": [
     "src",
     "redux-form.js",
     "redux-form-immutable.js"
-  ]
+  ],
+  "devDependencies": {
+    "react-native": "^0.40.0",
+    "react-native-vector-icons": "^3.0.0"
+  },
+  "peerDependencies": {
+    "react-native": "*"
+  },
+  "dependencies": {
+    "styled-components": "^1.2.1"
+  }
 }


### PR DESCRIPTION
If you have react native and react-native-vector-icons as dependency in your
project you get naming collisions.