### PR TITLE
Pass through input properties

### DIFF
--- a/example/src/Form.js
+++ b/example/src/Form.js
@@ -41,8 +41,9 @@ class FormView extends Component {
           <Fieldset label="Contact details">
             <Input name="first_name" label="First name" placeholder="John" />
             <Input name="last_name" label="Last name" placeholder="Doe" />
-            <Input name="email" label="Email" placeholder="something@domain.com" />
-            <Input name="telephone" label="Phone" placeholder="+45 88 88 88 88" />
+            <Input name="email" label="Email" placeholder="something@domain.com" keyboardType="email-address" returnKeyType="next" blurOnSubmit={false} />
+            <Input name="telephone" label="Phone" placeholder="+45 88 88 88 88" dataDetectorTypes="phoneNumber" keyboardType="phone-pad" />
+            <Input name="message" label="Message" placeholder="" multiline={true} numberOfLines={5}  inlineLabel={false} />
           </Fieldset>
           <Fieldset label="Shipping details" last>
             <Input name="address" label="Address" placeholder="Hejrevej 33" />

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -1,7 +1,29 @@
 import React from 'react'
-import { View } from 'react-native'
+import { View, TextInput } from 'react-native'
 import styled from 'styled-components/native'
+import _ from 'lodash'
 import defaultTheme from './theme'
+
+/**
+ * Calculate the height based on the given field properties.
+ * The inline label and multiline properties affect the height.
+ * 
+ * @param {Object} props
+ * @returns {int}
+ */
+const calculateHeight = (props) => {
+  let height = props.theme.FormGroup.height
+
+  if (props.multiline) {
+    height = props.theme.FormGroup.height * props.numberOfLines
+  }
+
+  if (!props.inlineLabel) {
+    height += props.theme.Label.stackedHeight
+  }
+
+  return (height)
+}
 
 const FormGroupWrapper = styled.View`
   align-items: ${props => props.inlineLabel ? 'center' : 'stretch' };
@@ -11,7 +33,7 @@ const FormGroupWrapper = styled.View`
   border-width: ${props => props.border ? props.theme.FormGroup.borderWidth : 0};
   flex-direction: ${props => props.inlineLabel ? 'row' : 'column' };
   justify-content: flex-start;
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height : props.theme.FormGroup.height + props.theme.Label.stackedHeight};
+  height: ${props => calculateHeight(props)};
   marginBottom: ${props => props.theme.FormGroup.marginBottom};
   padding: ${props => props.theme.FormGroup.padding};
 `
@@ -21,15 +43,21 @@ FormGroupWrapper.defaultProps = {
 }
 
 const FormGroup = props => {
-  const { border, error, inlineLabel } = props
+  const { border, error, inlineLabel, multiline, numberOfLines, keyboardType, returnKeyType } = props
   const children = React.Children.map(props.children, child => {
+    let subsetOfProps = {}
+    if (child.type.name === 'Input') {
+      const inputPropTypes = Object.keys(child.type.PropTypes)
+      subsetOfProps = _.pick(props, inputPropTypes);
+    }
+
     return React.cloneElement(child, Object.assign({}, child.props, {
-      inlineLabel
+      inlineLabel, ...subsetOfProps
     }))
   })
 
   return (
-    <FormGroupWrapper border={border} error={error} inlineLabel={inlineLabel}>
+    <FormGroupWrapper border={border} error={error} inlineLabel={inlineLabel} multiline={multiline} numberOfLines={numberOfLines}>
       { children }
     </FormGroupWrapper>
   )
@@ -38,13 +66,14 @@ const FormGroup = props => {
 FormGroup.PropTypes = {
   border: React.PropTypes.bool,
   error: React.PropTypes.bool,
-  inlineLabel: React.PropTypes.bool
 }
 
 FormGroup.defaultProps = {
   border: true,
   error: false,
-  inlineLabel: true
+  inlineLabel: true,
+  numberOfLines: 1,
+  multiline: false
 }
 
 export default FormGroup

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,12 +1,33 @@
 import React from 'react'
-import { TextInput, View } from 'react-native'
+import {TextInput, View} from 'react-native'
 import styled from 'styled-components/native'
 import defaultTheme from './theme'
 
+/**
+ * Calculate the height based on the given field properties.
+ * The inline label and multiline properties affect the height.
+ * 
+ * @param {Object} props
+ * @returns {int}
+ */
+const calculateHeight = (props) => {
+  let height = props.theme.FormGroup.height
+
+  if (props.multiline) {
+    height = props.theme.FormGroup.height * (props.numberOfLines - 1)
+  }
+
+  if (props.inlineLabel) {
+    height -= props.theme.FormGroup.borderWidth * 2
+  }
+
+  return (height)
+}
+
 // When doing stacked labels we want the input to be greedy
-const InputWrapper = styled.View`
-  flex: ${props => props.inlineLabel ? .5 : 1};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
+const InputWrapper = styled.View `
+  flex: ${props => props.inlineLabel ? .5: 1};
+  height: ${props => calculateHeight(props)};
 `
 
 InputWrapper.defaultProps = {
@@ -14,10 +35,10 @@ InputWrapper.defaultProps = {
 }
 
 // Subtract the border of the form group to have a full height input
-const StyledInput = styled.TextInput`
+const StyledInput = styled.TextInput `
   color: ${props => props.theme.Input.color};
   font-size: ${props => props.theme.BaseInput.fontSize};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
+  height: ${props => calculateHeight(props)};
   line-height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
 `
 
@@ -25,17 +46,21 @@ StyledInput.defaultProps = {
   theme: defaultTheme
 }
 
-const Input = props => (
-  <InputWrapper inlineLabel={props.inlineLabel}>
-    <StyledInput
-      inlineLabel={props.inlineLabel}
-      placeholderTextColor={props.theme.BaseInput.placeholderColor}
-      {...props}
-    />
-  </InputWrapper>
-)
+class Input extends React.Component {
+  render() {
+    return (
+      <InputWrapper inlineLabel={this.props.inlineLabel}>
+        <StyledInput
+          inlineLabel={this.props.inlineLabel}
+          placeholderTextColor={this.props.theme.BaseInput.placeholderColor}
+          {...this.props}/>
+      </InputWrapper>
+    )
+  }
+}
 
 Input.PropTypes = {
+  ...TextInput.propTypes,
   inlineLabel: React.PropTypes.bool.isRequired
 }
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -4,7 +4,6 @@ import styled from 'styled-components/native'
 import defaultTheme from './theme'
 
 const LabelWrapper = styled.View`
-  flex:.5;
   marginTop: ${props => props.inlineLabel ? 0 : 5};
 `
 

--- a/src/redux-form/createInputCreator.js
+++ b/src/redux-form/createInputCreator.js
@@ -20,7 +20,7 @@ const render = renderComponent => props => {
 
   return (
     <View>
-      <FormGroup border={border} inlineLabel={inlineLabel} error={touched && !!error}>
+      <FormGroup border={border} inlineLabel={inlineLabel} error={touched && !!error} {...props} >
         <Label>{ label }</Label>
         { renderComponent(props) }
       </FormGroup>


### PR DESCRIPTION
React-native comes with lots of components. Especially the TextInput component uses a lot of properties that are necessary for the usability of a form.

In the current version the clean form Input component does not support the general TextInput components.

Fixes: #4
