### PR TITLE
Change the android app styles

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -36,6 +36,8 @@ const ButtonTextWrapper = styled.View`
 
 const ButtonText = styled.Text`
   color: ${props => props.theme.Button.color};
+  font-size: ${props => props.theme.Button.fontSize};
+  font-weight: ${props => props.theme.Button.fontWeight};
 `
 
 ButtonText.defaultProps = {

--- a/src/Button.js
+++ b/src/Button.js
@@ -13,6 +13,9 @@ import defaultTheme from './theme'
 
 const ButtonWrapper = styled.View`
   flex:1;
+  align-self: stretch;
+  flex-direction: column;
+  justify-content: center;
 `
 
 const ButtonStyle = styled.View`
@@ -26,17 +29,13 @@ ButtonStyle.defaultProps = {
 
 const ButtonTextWrapper = styled.View`
   flex:1;
-  flex-direction:row;
-  align-items:center;
-  justify-content:center;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
 `
 
 const ButtonText = styled.Text`
   color: ${props => props.theme.Button.color};
-  font-size: ${props => props.theme.Button.fontSize};
-  font-weight: ${props => props.theme.Button.fontWeight};
-  height: ${props => props.theme.Button.height};
-  line-height: ${props => props.theme.Button.height};
 `
 
 ButtonText.defaultProps = {
@@ -81,17 +80,9 @@ const Button = props => {
       <Touchable {...rest}>
         <ButtonStyle>
           <ButtonTextWrapper>
-            {
-              iconPlacement === 'left' &&
-                IconWrapped
-            }
-            <ButtonText>
-              { children }
-            </ButtonText>
-            {
-              iconPlacement === 'right' &&
-                IconWrapped
-            }
+            {iconPlacement === 'left' && IconWrapped}
+            <ButtonText>{ children }</ButtonText>
+            {iconPlacement === 'right' && IconWrapped}
           </ButtonTextWrapper>
         </ButtonStyle>
       </Touchable>

--- a/src/Input.js
+++ b/src/Input.js
@@ -6,7 +6,7 @@ import defaultTheme from './theme'
 /**
  * Calculate the height based on the given field properties.
  * The inline label and multiline properties affect the height.
- * 
+ *
  * @param {Object} props
  * @returns {int}
  */
@@ -24,11 +24,49 @@ const calculateHeight = (props) => {
   return (height)
 }
 
+/**
+ * Calculates the flex value based on the inlineLabel and numberOfLines
+ * properties.
+ *
+ * @param {Object} props
+ * @returns {string}
+ */
+const calculateFlexValue = (props) => {
+  let flex = 1
+
+  if (props.multiline && props.numberOfLines > 0) {
+    flex = props.numberOfLines + 1
+  }
+
+  if (props.inlineLabel) {
+    flex = 0.5
+  }
+
+  return (flex)
+}
+
+/**
+ * Decide how the text should be aligned for the input. This decision is based upon
+ * the field properties. A multiline input should start top and not centered.
+ *
+ * @param {Object} props
+ * @returns {string}
+ */
+const determineTextOrientation = (props) => {
+  let orientation = 'center'
+
+  if (props.multiline && props.numberOfLines > 1) {
+    orientation = 'top'
+  }
+
+  return (orientation)
+}
+
 // When doing stacked labels we want the input to be greedy
 const InputWrapper = styled.View`
-  flex: ${props => props.inlineLabel ? .5 : 1};
+  flex: ${props => calculateFlexValue(props)};
   justify-content: center;
-  height: ${props => props.theme.FormGroup.height};
+  height: ${props => calculateHeight(props)};
 `
 
 InputWrapper.defaultProps = {
@@ -41,7 +79,8 @@ const StyledInput = styled.TextInput`
   color: ${props => props.theme.Input.color};
   font-size: ${props => props.theme.BaseInput.fontSize};
   height: ${props => calculateHeight(props)};
-  line-height: ${props => props.theme.FormGroup.height};
+  line-height: ${props => props.theme.BaseInput.lineHeight};
+  text-align-vertical: ${props => determineTextOrientation(props)};
 `
 
 StyledInput.defaultProps = {
@@ -51,7 +90,10 @@ StyledInput.defaultProps = {
 class Input extends React.Component {
   render() {
     return (
-      <InputWrapper inlineLabel={this.props.inlineLabel}>
+      <InputWrapper
+        inlineLabel={this.props.inlineLabel}
+        multiline={this.props.multiline}
+        numberOfLines={this.props.numberOfLines}>
         <StyledInput
           inlineLabel={this.props.inlineLabel}
           placeholderTextColor={this.props.theme.BaseInput.placeholderColor}

--- a/src/Input.js
+++ b/src/Input.js
@@ -6,7 +6,8 @@ import defaultTheme from './theme'
 // When doing stacked labels we want the input to be greedy
 const InputWrapper = styled.View`
   flex: ${props => props.inlineLabel ? .5 : 1};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
+  justify-content: center;
+  height: ${props => props.theme.FormGroup.height};
 `
 
 InputWrapper.defaultProps = {
@@ -15,10 +16,11 @@ InputWrapper.defaultProps = {
 
 // Subtract the border of the form group to have a full height input
 const StyledInput = styled.TextInput`
+  flex: ${props => props.inlineLabel ? .5 : 1};
   color: ${props => props.theme.Input.color};
   font-size: ${props => props.theme.BaseInput.fontSize};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
-  line-height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height};
+  height: ${props => props.theme.FormGroup.height};
+  line-height: ${props => props.theme.FormGroup.height};
 `
 
 StyledInput.defaultProps = {

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Text, View } from 'react-native'
+import { Text, View, Platform } from 'react-native'
 import styled from 'styled-components/native'
 import defaultTheme from './theme'
 
@@ -8,6 +8,7 @@ const LabelWrapper = styled.View`
   flex-direction: ${props => props.inlineLabel ? 'row' : 'column'};
   flex-direction: column;
   justify-content: center;
+  padding-left: ${Platform.OS === 'android' ? 5 : 0};
   marginTop: ${props => props.inlineLabel ? 0 : 5};
 `
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -4,15 +4,16 @@ import styled from 'styled-components/native'
 import defaultTheme from './theme'
 
 const LabelWrapper = styled.View`
-  flex:.5;
+  flex: ${props => props.inlineLabel ? 0.5 : 1};
+  flex-direction: ${props => props.inlineLabel ? 'row' : 'column'};
+  flex-direction: column;
+  justify-content: center;
   marginTop: ${props => props.inlineLabel ? 0 : 5};
 `
 
 const LabelText = styled.Text`
   color: ${props => props.theme.Label.color};
   font-size: ${props => props.theme.Label.fontSize};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.Label.stackedHeight};
-  line-height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.Label.stackedHeight};
 `
 
 LabelText.defaultProps = {

--- a/src/Select.js
+++ b/src/Select.js
@@ -15,8 +15,6 @@ const HaveNoIdeaWhyThisIsNeeded=3
 
 const SelectLabel = styled.Text`
   font-size: ${props => props.theme.BaseInput.fontSize};
-  height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height-HaveNoIdeaWhyThisIsNeeded};
-  line-height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height-HaveNoIdeaWhyThisIsNeeded};
   flex:1;
 `
 
@@ -25,7 +23,8 @@ SelectLabel.defaultProps = {
 }
 
 const LabelIconWrapper = styled.View`
-  align-items:center;
+  justify-content: center;
+  align-items: center;
   flex-direction:row;
   height: ${props => props.inlineLabel ? props.theme.FormGroup.height - props.theme.FormGroup.borderWidth*2 : props.theme.FormGroup.height-HaveNoIdeaWhyThisIsNeeded};
 `

--- a/src/theme.js
+++ b/src/theme.js
@@ -29,7 +29,8 @@ const theme = {
   },
   BaseInput: {
     placeholderColor: '#c9c9c9',
-    fontSize: 12
+    fontSize: 12,
+    lineHeight: 18
   },
   Input: {
     color: '#313131',

--- a/src/theme.js
+++ b/src/theme.js
@@ -37,7 +37,7 @@ const theme = {
   Label: {
     color: '#bfc2c9',
     fontSize: 12,
-    stackedHeight: 20
+    stackedHeight: 40
   },
   Select: {
 


### PR DESCRIPTION
The style of the android app is not optimal. The most text components are not centered vertically
and the input text changes the height depending on the inlineLabel property.

This commit does not remove the input lines because this is a component property of
text-input in react native and can be changed in the general behavior.

But to change this you also need the pull request 15.

https://github.com/esbenp/react-native-clean-form/pull/15

Fixes: #9