### PR TITLE
Fix the pass thru of properties in release-mode

### DIFF
--- a/src/ActionsContainer.js
+++ b/src/ActionsContainer.js
@@ -8,7 +8,8 @@ const ButtonGroup = styled.View`
 `
 
 ButtonGroup.defaultProps = {
-  theme: defaultTheme
+  theme: defaultTheme,
+  componentName: 'ButtonGroup'
 }
 
 export default ButtonGroup

--- a/src/Button.js
+++ b/src/Button.js
@@ -41,7 +41,8 @@ const ButtonText = styled.Text`
 `
 
 ButtonText.defaultProps = {
-  theme: defaultTheme
+  theme: defaultTheme,
+  componentName: 'Button'
 }
 
 const Button = props => {

--- a/src/Fieldset.js
+++ b/src/Fieldset.js
@@ -50,6 +50,7 @@ Fieldset.PropTypes = {
 }
 
 Fieldset.defaultProps = {
+  componentName: 'Fieldset',
   last: false,
   label: false,
   theme: defaultTheme

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -39,14 +39,15 @@ const FormGroupWrapper = styled.View`
 `
 
 FormGroupWrapper.defaultProps = {
-  theme: defaultTheme
+  theme: defaultTheme,
+  componentName: 'FormGroupWrapper'
 }
 
 const FormGroup = props => {
   const { border, error, inlineLabel, theme, multiline, numberOfLines, keyboardType, returnKeyType } = props
   const children = React.Children.map(props.children, child => {
     let subsetOfProps = {}
-    if (child.type.name === 'Input') {
+    if (child.props.componentName === 'Input') {
       const inputPropTypes = Object.keys(child.type.PropTypes)
       subsetOfProps = _.pick(props, inputPropTypes);
     }
@@ -69,6 +70,7 @@ FormGroup.PropTypes = {
 }
 
 FormGroup.defaultProps = {
+  componentName: 'FormGroup',
   border: true,
   error: false,
   inlineLabel: true,

--- a/src/Input.js
+++ b/src/Input.js
@@ -109,6 +109,7 @@ Input.PropTypes = {
 }
 
 Input.defaultProps = {
+  componentName: 'Input',
   inlineLabel: true,
   theme: defaultTheme
 }

--- a/src/Label.js
+++ b/src/Label.js
@@ -18,7 +18,8 @@ const LabelText = styled.Text`
 `
 
 LabelText.defaultProps = {
-  theme: defaultTheme
+  theme: defaultTheme,
+  componentName: 'Label',
 }
 
 const Label = props => {

--- a/src/Select.js
+++ b/src/Select.js
@@ -145,7 +145,7 @@ Select.PropTypes = {
 }
 
 Select.defaultProps = {
-  componentName: 'Label',
+  componentName: 'Select',
   onValueChange: () => {},
   placeholder: '',
   labelKey: 'label',

--- a/src/Select.js
+++ b/src/Select.js
@@ -145,6 +145,7 @@ Select.PropTypes = {
 }
 
 Select.defaultProps = {
+  componentName: 'Label',
   onValueChange: () => {},
   placeholder: '',
   labelKey: 'label',

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -9,7 +9,8 @@ const Switch = styled(BaseSwitch)`
 Switch.PropTypes = BaseSwitch.PropTypes
 
 Switch.defaultProps = Object.assign({}, BaseSwitch.defaultProps, {
-  theme: defaultTheme
+  theme: defaultTheme,
+  componentName: 'Switch',
 })
 
 export default Switch


### PR DESCRIPTION
In the release mode, the form properties have not been passed thru.

The type of the component was not accessible in the release mode.
So now we have a property componentName to fix that.

Fixes: #28 