### PR TITLE
Pass thru custom theme to FormGroup and Select

### DIFF
--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -57,7 +57,8 @@ const FormGroup = props => {
   })
 
   return (
-    <FormGroupWrapper border={border} error={error} inlineLabel={inlineLabel} multiline={multiline} numberOfLines={numberOfLines}>
+    <FormGroupWrapper border={border} error={error} inlineLabel={inlineLabel}
+      multiline={multiline} numberOfLines={numberOfLines} theme={theme}>
       { children }
     </FormGroupWrapper>
   )

--- a/src/Select.js
+++ b/src/Select.js
@@ -90,7 +90,16 @@ class Select extends Component {
   }
 
   render() {
-    const { inlineLabel, labelKey, options, onValueChange, placeholder, valueKey, ...rest } = this.props
+    const {
+      inlineLabel,
+      labelKey,
+      options,
+      onValueChange,
+      placeholder,
+      valueKey,
+      theme,
+      ...rest
+    } = this.props
     const { showSelector, value } = this.state
 
     const labelsByValue = options.reduce((carry, option) => {
@@ -104,7 +113,7 @@ class Select extends Component {
     }
 
     return (
-      <SelectWrapper inlineLabel={inlineLabel}>
+      <SelectWrapper inlineLabel={inlineLabel} theme={theme}>
         <Modal
           onRequestClose={this.toggleSelector}
           visible={showSelector}


### PR DESCRIPTION
In some components, the custom theme is not used. The reason for that is that the theme property is not passed thru to the styledcomponents. For instance in the FormGroup.

Fixes: #32