### PR TITLE
[BUGFIX] Show ActivityIndicator also when no icon has been set

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -61,7 +61,7 @@ const Button = props => {
   ]
 
   let IconWrapped = null
-  if (icon) {
+  if (icon || submitting) {
     const IconComponent = submitting
       ? <ActivityIndicator size="small" key="icon" color={theme.Button.color} />
       : <Icon key="icon" name={icon} size={14} color={theme.Button.color} />


### PR DESCRIPTION
You probably don`t want to show an icon in you submit button but want to see the activity indicator when you submit the data.

This little bugfix adjusts the condition in the button component.

Thanks to @giautm for reporting this issue :)

Fixes: #43