### PR TITLE
Fix padding value conflict

### DIFF
--- a/src/Theme.js
+++ b/src/Theme.js
@@ -19,7 +19,8 @@ const Theme = {
     labelSize: 9,
     labelWeight: 700,
     labelHeight: 25,
-    padding: '12 8'
+    paddingTop: 12,
+    paddingRight :8
   },
   FormGroup: {
     borderColor: '#ebebeb',
@@ -29,7 +30,8 @@ const Theme = {
     errorBorderColor: 'red',
     height: 35,
     marginBottom: 10,
-    padding: '0 10'
+    paddingTop: 0,
+    paddingRight: 10
   },
   BaseInput: {
     placeholderColor: '#c9c9c9',


### PR DESCRIPTION

<img width="1680" alt="screen shot 2017-06-25 at 10 30 28 am" src="https://user-images.githubusercontent.com/18385578/27515031-3d9279d2-5992-11e7-8dbf-0c56c6af9c2e.png">

Split the padding property into paddingTop and paddingRight due to errors "Failed To pass declaration " padding: 12 8"

Check image above for description.