### PR TITLE
Allows redux-form components to pass along other props

### DIFF
--- a/src/redux-form/createInputs.js
+++ b/src/redux-form/createInputs.js
@@ -10,12 +10,12 @@ import {
 } from '../../index'
 
 const createInputs = inputCreator => {
-  const renderInput = ({ input: { onChange, ...restInput }, placeholder}) => (
-    <InputRenderer onChangeText={onChange} placeholder={placeholder} {...restInput} />
+  const renderInput = ({ input: { onChange, ...restInput }, placeholder},...restProps) => (
+    <InputRenderer onChangeText={onChange} placeholder={placeholder} {...restInput} {...restProps}/>
   )
   const Input = inputCreator('Input', renderInput, InputRenderer.PropTypes, InputRenderer.defaultProps)
 
-  const renderSelect = ({ input: { onChange, value }, labelKey, valueKey, options, placeholder }) => (
+  const renderSelect = ({ input: { onChange, value }, labelKey, valueKey, options, placeholder ,...restProps}) => (
     <SelectRenderer
       labelKey={labelKey}
       options={options}
@@ -23,17 +23,18 @@ const createInputs = inputCreator => {
       placeholder={placeholder}
       value={value}
       valueKey={valueKey}
+	  {...restProps}
     />
   )
   const Select = inputCreator('Select', renderSelect, SelectRenderer.PropTypes, SelectRenderer.defaultProps)
 
-  const renderSwitch = ({ input: { onChange, value }}) => {
+  const renderSwitch = ({ input: { onChange, value}, ...restProps }) => {
     // redux-form default value is '', however Switch must take a boolean value
     if (value === '') {
       value = SwitchRenderer.defaultProps.value
     }
 
-    return <SwitchRenderer onValueChange={onChange} value={value} />
+    return <SwitchRenderer onValueChange={onChange} value={value} {...restProps}/>
   }
   const Switch = inputCreator('Switch', renderSwitch, SwitchRenderer.PropTypes, SwitchRenderer.defaultProps)
 


### PR DESCRIPTION
**Quickfix to createInput.js, and now we can actually style the react-native-clean-form/redux-form Switch:**
There will be many reasons why developers may want these components to be able to receive props other than the ones passed along by createInput. 
I found this change to be a must if you want to be able to style the Switch component at all.