### PR TITLE
Replace deprecated usages of React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "styled-components": ">=1.4",
-    "react-native-vector-icons": ">=4.0.0"
+    "react-native-vector-icons": ">=4.0.0",
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/Button.js
+++ b/src/Button.js
@@ -8,6 +8,7 @@ import {
   View
 } from 'react-native'
 import styled from 'styled-components/native'
+import PropTypes from 'prop-types'
 import Icon from 'react-native-vector-icons/Ionicons'
 import defaultTheme from './Theme'
 
@@ -96,10 +97,10 @@ const Button = props => {
 }
 
 Button.PropTypes = {
-  children: React.PropTypes.string.isRequired,
-  icon: React.PropTypes.string,
-  iconPlacement: React.PropTypes.oneOf(['left', 'right']),
-  submitting: React.PropTypes.bool
+  children: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  iconPlacement: PropTypes.oneOf(['left', 'right']),
+  submitting: PropTypes.bool
 }
 
 Button.defaultProps = {

--- a/src/Fieldset.js
+++ b/src/Fieldset.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Text, View } from 'react-native'
+import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import defaultTheme from './Theme'
 
@@ -48,8 +49,8 @@ const Fieldset = props => {
 }
 
 Fieldset.PropTypes = {
-  last: React.PropTypes.bool,
-  label: React.PropTypes.string
+  last: PropTypes.bool,
+  label: PropTypes.string
 }
 
 Fieldset.defaultProps = {

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { View, TextInput } from 'react-native'
+import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import _ from 'lodash'
 import defaultTheme from './Theme'
@@ -69,8 +70,8 @@ const FormGroup = props => {
 }
 
 FormGroup.PropTypes = {
-  border: React.PropTypes.bool,
-  error: React.PropTypes.bool,
+  border: PropTypes.bool,
+  error: PropTypes.bool,
 }
 
 FormGroup.defaultProps = {

--- a/src/Input.js
+++ b/src/Input.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {TextInput, View} from 'react-native'
+import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import defaultTheme from './Theme'
 
@@ -82,7 +83,7 @@ class Input extends React.Component {
 
 Input.PropTypes = {
   ...TextInput.propTypes,
-  inlineLabel: React.PropTypes.bool.isRequired
+  inlineLabel: PropTypes.bool.isRequired
 }
 
 Input.defaultProps = {

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Text, View, Platform } from 'react-native'
+import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import defaultTheme from './Theme'
 
@@ -33,7 +34,7 @@ const Label = props => {
 }
 
 Label.PropTypes = {
-  children: React.PropTypes.string.isRequired
+  children: PropTypes.string.isRequired
 }
 
 export default Label

--- a/src/Select.js
+++ b/src/Select.js
@@ -6,6 +6,7 @@ import {
   TouchableOpacity,
   View
 } from 'react-native'
+import PropTypes from 'prop-types'
 import styled from 'styled-components/native'
 import { default as BaseIcon } from 'react-native-vector-icons/Ionicons';
 import defaultTheme from './Theme'
@@ -142,14 +143,14 @@ class Select extends Component {
 }
 
 Select.PropTypes = {
-  labelKey: React.PropTypes.string,
-  placeholder: React.PropTypes.string,
-  onValueChange: React.PropTypes.func.isRequired,
-  options: React.PropTypes.array.isRequired,
-  valueKey: React.PropTypes.string,
-  value: React.PropTypes.oneOf([
-    React.PropTypes.string,
-    React.PropTypes.number
+  labelKey: PropTypes.string,
+  placeholder: PropTypes.string,
+  onValueChange: PropTypes.func.isRequired,
+  options: PropTypes.array.isRequired,
+  valueKey: PropTypes.string,
+  value: PropTypes.oneOf([
+    PropTypes.string,
+    PropTypes.number
   ])
 }
 

--- a/src/redux-form/createInputCreator.js
+++ b/src/redux-form/createInputCreator.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { View } from 'react-native'
+import PropTypes from 'prop-types'
 import { FormGroup, Label } from '../../index'
 import styled from 'styled-components/native'
 import defaultTheme from '../Theme'
@@ -30,7 +31,7 @@ const render = renderComponent => props => {
 }
 
 
-const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, PropTypes = {}, defaultProps = {}) => {
+const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, PropTypesOverrides = {}, defaultProps = {}) => {
   const Component = render(renderFunction)
   Component.displayName = name
 
@@ -42,11 +43,11 @@ const createInputCreator = ReduxFormFieldComponent => (name, renderFunction, Pro
 
   FieldWrapper.displayName = 'FieldWrapper'
   FieldWrapper.PropTypes = Object.assign({
-    border: React.PropTypes.bool,
-    inlineLabel: React.PropTypes.bool,
-    label: React.PropTypes.string.isRequired,
-    name: React.PropTypes.string.isRequired
-  }, PropTypes)
+    border: PropTypes.bool,
+    inlineLabel: PropTypes.bool,
+    label: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }, PropTypesOverrides)
   FieldWrapper.defaultProps = Object.assign({
     border: FormGroup.defaultProps.border,
     inlineLabel: FormGroup.defaultProps.inlineLabel


### PR DESCRIPTION
Fixes https://github.com/esbenp/react-native-clean-form/issues/70.

There's a previous attempt from PR https://github.com/esbenp/react-native-clean-form/pull/69. However, the fix is incomplete.
This PR is a superset of the previous PR:
> Replaced React.PropTypes with PropTypes from the prop-types package to support React 16 and higher.